### PR TITLE
bugfix/ci_python_version

### DIFF
--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: [3.9, "3.10", 3.11]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
### Description 
bugfix to resolve #6. When updating the cookiecutter we removed quotations from python 3.10 in ci.yml. This causes tests on python 3.1 rather than 3.10.